### PR TITLE
Add UserProfile to Identity API

### DIFF
--- a/src/Identity.API/Data/ApplicationDbContext.cs
+++ b/src/Identity.API/Data/ApplicationDbContext.cs
@@ -7,6 +7,8 @@
 /// </remarks>
 public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 {
+    public DbSet<UserProfile> UserProfiles { get; set; }
+
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
     {
@@ -18,5 +20,11 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
         // Customize the ASP.NET Identity model and override the defaults if needed.
         // For example, you can rename the ASP.NET Identity table names and more.
         // Add your customizations after calling base.OnModelCreating(builder);
+
+        builder.Entity<UserProfile>()
+            .HasOne(p => p.User)
+            .WithOne()
+            .HasForeignKey<UserProfile>(p => p.UserId)
+            .IsRequired();
     }
 }

--- a/src/Identity.API/Data/Migrations/20240101000000_AddUserProfile.cs
+++ b/src/Identity.API/Data/Migrations/20240101000000_AddUserProfile.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace eShop.Identity.API.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "text", nullable: false),
+                    UserId = table.Column<string>(type: "text", nullable: false),
+                    ShopName = table.Column<string>(type: "text", nullable: true),
+                    ShopUrl = table.Column<string>(type: "text", nullable: true),
+                    ShopDescription = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserProfiles", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserProfiles_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserProfiles_UserId",
+                table: "UserProfiles",
+                column: "UserId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserProfiles");
+        }
+    }
+}

--- a/src/Identity.API/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Identity.API/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -315,6 +315,43 @@ namespace eShop.Identity.API.Data.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
+
+            modelBuilder.Entity("eShop.Identity.API.Models.UserProfile", b =>
+                {
+                    b.Property<string>("Id")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ShopDescription")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ShopName")
+                        .HasColumnType("text");
+
+                    b.Property<string>("ShopUrl")
+                        .HasColumnType("text");
+
+                    b.Property<string>("UserId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId")
+                        .IsUnique();
+
+                    b.ToTable("UserProfiles", (string)null);
+                });
+
+            modelBuilder.Entity("eShop.Identity.API.Models.UserProfile", b =>
+                {
+                    b.HasOne("eShop.Identity.API.Models.ApplicationUser", "User")
+                        .WithOne()
+                        .HasForeignKey("eShop.Identity.API.Models.UserProfile", "UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
+                });
 #pragma warning restore 612, 618
         }
     }

--- a/src/Identity.API/Models/UserProfile.cs
+++ b/src/Identity.API/Models/UserProfile.cs
@@ -1,0 +1,18 @@
+namespace eShop.Identity.API.Models;
+
+public class UserProfile
+{
+    [Key]
+    public string Id { get; set; }
+
+    [Required]
+    public string UserId { get; set; }
+
+    public ApplicationUser User { get; set; }
+
+    public string ShopName { get; set; }
+
+    public string ShopUrl { get; set; }
+
+    public string ShopDescription { get; set; }
+}


### PR DESCRIPTION
## Summary
- create `UserProfile` entity to store shop information
- register `UserProfiles` in `ApplicationDbContext`
- add EF Core migration for new table
- update model snapshot for new schema

## Testing
- `dotnet test eShop.Web.slnf` *(failed: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c7d8d0748322ad0e96cb18583b18